### PR TITLE
Catch JSON.parse() errors

### DIFF
--- a/device.js
+++ b/device.js
@@ -32,7 +32,12 @@ var jsonRpcQuery = function(host, port, method, callback) {
             response += data;
         });
         res.on('end', function() {
-            var result = JSON.parse(response);
+            var result;
+            try {
+                result = JSON.parse(response);
+            } catch (err) {
+                callback({status: 'error'});
+            }
             if( !('result' in result) && result.result !== 'ok' ) {
                 callback({status: 'error'});
             }


### PR DESCRIPTION
JSON.parse() can throw errors, so it should always be wrapped in a try-catch block.

This caused an uncaught exception in [WebTorrent](https://webtorrent.io/), which uses nodebmc. Issue here: https://github.com/feross/webtorrent/issues/805
