### PR TITLE
Sometimes result is undefined and crashes

### DIFF
--- a/device.js
+++ b/device.js
@@ -38,7 +38,7 @@ var jsonRpcQuery = function(host, port, method, callback) {
             } catch (err) {
                 callback({status: 'error'});
             }
-            if( !('result' in result) && result.result !== 'ok' ) {
+            if( result === undefined || (!('result' in result) && result.result !== 'ok' )) {
                 callback({status: 'error'});
             }
             else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodebmc",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "A XBMC RPC client for node.js",
     "main": "index.js",
     "keywords": [


### PR DESCRIPTION
Sometimes result is undefined and "'result' in result" crashes app when using webtorrent cli to play video on xbmc

This is the error I get: TypeError: Cannot use 'in' operator to search for 'result' in undefined 

Adding an undefined check helps prevent webtorrent from crashing. Maybe you could check 'response' further up but this seems to work.

using node v8.4.0